### PR TITLE
core : create intermediate burst function for dipole

### DIFF
--- a/core/packetgraph/brick.h
+++ b/core/packetgraph/brick.h
@@ -64,6 +64,11 @@ int pg_brick_burst_to_west(struct pg_brick *brick, uint16_t edge_index,
 			   struct rte_mbuf **pkts, uint64_t pkts_mask,
 			   struct pg_error **errp);
 
+/* data flow for bricks */
+int pg_brick_edge_side_forward(struct pg_brick *brick, enum pg_side from,
+			       uint16_t edge_index,
+			       struct rte_mbuf **pkts, uint64_t pkts_mask,
+			       struct pg_error **errp);
 /* used for testing */
 struct rte_mbuf **pg_brick_west_burst_get(struct pg_brick *brick,
 					  uint64_t *pkts_mask,

--- a/core/src/bricks.c
+++ b/core/src/bricks.c
@@ -718,7 +718,16 @@ uint64_t pg_brick_pkts_count_get(struct pg_brick *brick, enum pg_side side)
 	}
 	return 0;
 }
-
+int pg_brick_edge_side_forward(struct pg_brick *brick, enum pg_side from,
+			       uint16_t edge_index,
+			       struct rte_mbuf **pkts, uint64_t pkts_mask,
+			       struct pg_error **errp)
+{
+	if (brick == NULL)
+		return -1;
+	return pg_brick_burst(brick, from,
+			      edge_index, pkts, pkts_mask, errp);
+}
 const char *pg_brick_name(struct pg_brick *brick)
 {
 	return brick->name;

--- a/core/src/nop.c
+++ b/core/src/nop.c
@@ -31,11 +31,9 @@ static int nop_burst(struct pg_brick *brick, enum pg_side from,
 {
 	struct pg_brick_side *s = &brick->sides[pg_flip_side(from)];
 
-	if (s->edge.link == NULL)
-		return 0;
-	return  pg_brick_burst(s->edge.link, from,
-			       s->edge.pair_index,
-			       pkts, pkts_mask, errp);
+	return  pg_brick_edge_side_forward(s->edge.link, from,
+					   s->edge.pair_index,
+					   pkts, pkts_mask, errp);
 }
 
 static int nop_init(struct pg_brick *brick,


### PR DESCRIPTION
- avoid redundant code in all bricks config
- fix nop brick to use this function

Signed-off-by: Tarrade Nicolas <nicolas.tarrade@outscale.com>