### PR TITLE
build: move long tests at the end

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -253,14 +253,14 @@ TESTS = \
 	tests/rxtx/test.sh\
 	tests/pmtud/test.sh\
 	tests/firewall/test.sh\
-	tests/integration/test.sh\
 	tests/nic/test.sh\
 	tests/print/test.sh\
 	tests/queue/test.sh\
 	tests/switch/test.sh\
-	tests/vhost/test.sh\
 	tests/vtep/test.sh\
-	tests/tap/test.sh
+	tests/tap/test.sh\
+	tests/integration/test.sh\
+	tests/vhost/test.sh
 
 noinst_PROGRAMS = 
 


### PR DESCRIPTION
Note: just a quick practical fix, we don't want to pollute options for that