### PR TITLE
vhost: try to burst non-bursted packets

### DIFF
--- a/src/vhost.c
+++ b/src/vhost.c
@@ -137,6 +137,13 @@ static int vhost_burst(struct pg_brick *brick, enum pg_side from,
 					       VIRTIO_RXQ,
 					       state->out,
 					       pkts_count);
+	if (bursted_pkts < pkts_count) {
+		bursted_pkts += rte_vhost_enqueue_burst(
+			virtio_net,
+			VIRTIO_RXQ,
+			state->out + bursted_pkts,
+			pkts_count - bursted_pkts);
+	}
 	rte_atomic32_clear(&state->allow_queuing);
 
 	/* count tx bytes: burst is packed so we can directly iterate */


### PR DESCRIPTION
thats a workaround for #37 as vhost cannot burst more than 32 packets
per bursts. If all packets have not been bursts, we retry one more time.

Signed-off-by: Jerome Jutteau <jerome.jutteau@outscale.com>