### PR TITLE
all: remove memcpy, use rte_memcpy instead

### DIFF
--- a/src/antispoof.c
+++ b/src/antispoof.c
@@ -18,6 +18,7 @@
 #include <rte_config.h>
 #include <rte_ether.h>
 #include <rte_ip.h>
+#include <rte_memcpy.h>
 #include <packetgraph/packetgraph.h>
 #include "brick-int.h"
 #include "utils/bitmask.h"
@@ -178,7 +179,7 @@ static int antispoof_init(struct pg_brick *brick,
 	antispoof_config = (struct pg_antispoof_config *) config->brick_config;
 	brick->burst = antispoof_burst;
 	state->outside = antispoof_config->outside;
-	memcpy(&state->mac, &antispoof_config->mac, ETHER_ADDR_LEN);
+	rte_memcpy(&state->mac, &antispoof_config->mac, ETHER_ADDR_LEN);
 	state->ip = 0;
 
 	/* let's start the pre-build of ARP anti-spoof */
@@ -186,7 +187,7 @@ static int antispoof_init(struct pg_brick *brick,
 	state->arp_packet.ar_pro = htobe16(ETHER_TYPE_IPv4);
 	state->arp_packet.ar_hln = ETHER_ADDR_LEN;
 	state->arp_packet.ar_pln = 4;
-	memcpy(&state->arp_packet.sender_mac, &state->mac, ETHER_ADDR_LEN);
+	rte_memcpy(&state->arp_packet.sender_mac, &state->mac, ETHER_ADDR_LEN);
 
 	if (pg_error_is_set(errp))
 		return -1;

--- a/src/ip-fragment.c
+++ b/src/ip-fragment.c
@@ -21,6 +21,7 @@
 #include <rte_ip.h>
 #include <rte_ip_frag.h>
 #include <rte_ether.h>
+#include <rte_memcpy.h>
 #include "utils/mempool.h"
 #include "utils/bitmask.h"
 #include "packets.h"
@@ -88,8 +89,8 @@ static int do_fragmentation(struct pg_ip_fragment_state *state,
 
 	rte_pktmbuf_prepend(pkt, l2_size);
 	PG_FOREACH_BIT(mask, i) {
-		memcpy(rte_pktmbuf_prepend(pkts_out[i],
-					   l2_size),
+		rte_memcpy(rte_pktmbuf_prepend(pkts_out[i],
+					       l2_size),
 		       &eth, l2_size);
 		pkts_out[i]->l2_len = l2_size;
 		pkts_out[i]->udata64 |= PG_FRAGMENTED_MBUF;

--- a/src/packets.c
+++ b/src/packets.c
@@ -22,6 +22,7 @@
 #include <rte_udp.h>
 #include <rte_ip.h>
 #include <rte_ether.h>
+#include <rte_memcpy.h>
 
 #include <glib.h>
 #include <string.h>
@@ -67,7 +68,7 @@ struct rte_mbuf **pg_packets_append_blank(struct rte_mbuf **pkts,
 		tmp = rte_pktmbuf_##ops(pkts[j], len);		\
 		if (!tmp)					\
 			return NULL;				\
-		memcpy(tmp, buf, len);				\
+		rte_memcpy(tmp, buf, len);				\
 	}
 
 struct rte_mbuf **pg_packets_append_buf(struct rte_mbuf **pkts,
@@ -140,7 +141,7 @@ struct rte_mbuf **pg_packets_prepend_str(struct rte_mbuf **pkts,
 		tmp = rte_pktmbuf_##ops(pkts[j], sizeof(ip_hdr));	\
 		if (!tmp)						\
 			return NULL;					\
-		memcpy(tmp, &ip_hdr, sizeof(ip_hdr));			\
+		rte_memcpy(tmp, &ip_hdr, sizeof(ip_hdr));		\
 		pkts[j]->l3_len = sizeof(struct ipv4_hdr);		\
 	}								\
 
@@ -219,7 +220,7 @@ struct rte_mbuf **pg_packets_prepend_udp(struct rte_mbuf **pkts,
 		tmp = rte_pktmbuf_##ops(pkts[j], sizeof(vx_hdr));	\
 		if (!tmp)						\
 			return NULL;					\
-		memcpy(tmp, &vx_hdr, sizeof(vx_hdr));			\
+		rte_memcpy(tmp, &vx_hdr, sizeof(vx_hdr));		\
 	}								\
 
 struct rte_mbuf **pg_packets_append_vxlan(struct rte_mbuf **pkts,
@@ -255,7 +256,7 @@ struct rte_mbuf **pg_packets_prepend_vxlan(struct rte_mbuf **pkts,
 		tmp = rte_pktmbuf_##ops(pkts[j], sizeof(eth_hdr));	\
 		if (!tmp)						\
 			return NULL;					\
-		memcpy(tmp, &eth_hdr, sizeof(eth_hdr));			\
+		rte_memcpy(tmp, &eth_hdr, sizeof(eth_hdr));		\
 		pkts[j]->l2_len = sizeof(struct ether_hdr);		\
 	}								\
 

--- a/src/tap.c
+++ b/src/tap.c
@@ -26,6 +26,7 @@
 #include <rte_config.h>
 #include <rte_ethdev.h>
 #include <rte_cycles.h>
+#include <rte_memcpy.h>
 
 #include <packetgraph/packetgraph.h>
 #include "brick-int.h"
@@ -63,7 +64,7 @@ int pg_tap_get_mac(struct pg_brick *tap, struct ether_addr *addr)
 	fd = socket(PF_INET, SOCK_DGRAM, IPPROTO_IP);
 	if (ioctl(fd, SIOCGIFHWADDR, &i) < 0)
 		return -1;
-	memcpy(addr, i.ifr_addr.sa_data, 6);
+	rte_memcpy(addr, i.ifr_addr.sa_data, 6);
 	return 0;
 }
 

--- a/src/utils/bench.c
+++ b/src/utils/bench.c
@@ -20,6 +20,7 @@
 #include <glib/gstdio.h>
 #include <rte_config.h>
 #include <rte_ether.h>
+#include <rte_memcpy.h>
 #include <packetgraph/packetgraph.h>
 #include "utils/bench.h"
 #include "utils/bitmask.h"
@@ -166,7 +167,7 @@ int pg_bench_run(struct pg_bench *bench, struct pg_bench_stats *result,
 	result->pkts_average_size /= bench->pkts_nb;
 
 	/* Let's run ! */
-	memcpy(&bl, bench, sizeof(struct pg_bench));
+	rte_memcpy(&bl, bench, sizeof(struct pg_bench));
 	gettimeofday(&result->date_start, NULL);
 	for (i = 0; i < bl.max_burst_cnt; i++) {
 		/* Burst packets. */
@@ -186,7 +187,7 @@ int pg_bench_run(struct pg_bench *bench, struct pg_bench_stats *result,
 			bl.post_burst_op(bench);
 	}
 	gettimeofday(&result->date_end, NULL);
-	memcpy(bench, &bl, sizeof(struct pg_bench));
+	rte_memcpy(bench, &bl, sizeof(struct pg_bench));
 	result->pkts_sent = bench->max_burst_cnt * bench->pkts_nb;
 	result->burst_cnt = bench->max_burst_cnt;
 	result->pkts_burst = pkts_burst;

--- a/src/utils/mac-table.h
+++ b/src/utils/mac-table.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <rte_memcpy.h>
 #include "utils/mac.h"
 #include "utils/bitmask.h"
 
@@ -122,8 +123,8 @@ static inline void pg_mac_table_elem_set(struct pg_mac_table *ma,
 		return;
 
 	pg_mac_table_mask_set(*ma->elems[part1], part2);
-	memcpy(ma->elems[part1]->entries + (part2 * elem_size),
-	       entry, elem_size);
+	rte_memcpy(ma->elems[part1]->entries + (part2 * elem_size),
+		   entry, elem_size);
 }
 
 static inline void pg_mac_table_ptr_set(struct pg_mac_table *ma,

--- a/src/vtep.c
+++ b/src/vtep.c
@@ -488,7 +488,7 @@ static inline void add_dst_iner_macs(struct vtep_state *state,
 		pkt_addr = rte_pktmbuf_mtod(pkts[i], struct ether_hdr *);
 		ether_addr_copy(&hdrs[i]->ethernet.s_addr, &dst.mac);
 		dst.ip = hdrs[i]->ipv4.src_addr;
-		memcpy(tmp.bytes, &pkt_addr->s_addr.addr_bytes, 6);
+		rte_memcpy(tmp.bytes, &pkt_addr->s_addr.addr_bytes, 6);
 		pg_mac_table_elem_set(&port->mac_to_dst, tmp, &dst,
 				      sizeof(struct dest_addresses));
 	}


### PR DESCRIPTION
Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>