### PR TITLE
tests: add wrapper to g_test_add_func

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,6 +16,7 @@ libpacketgraph_la_SOURCES = \
 	src/utils/mac.c\
 	src/utils/config.c\
 	src/utils/bitmask.c\
+	src/utils/tests.c\
 	src/print.c\
 	src/hub.c\
 	src/brick.c\

--- a/src/utils/tests.c
+++ b/src/utils/tests.c
@@ -15,22 +15,6 @@
  * along with Butterfly.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <glib.h>
-#include <packetgraph/packetgraph.h>
-#include "utils/tests.h"
+#include "tests.h"
 
-void test_benchmark_tap(int argc, char **argv);
-
-int main(int argc, char **argv)
-{
-	struct pg_error *error = NULL;
-	int r;
-
-	g_test_init(&argc, &argv, NULL);
-	pg_start(argc, argv, &error);
-	g_assert(!error);
-	test_benchmark_tap(argc, argv);
-	r = g_test_run();
-	pg_stop();
-	return r;
-}
+int pg_skip_tests;

--- a/src/utils/tests.h
+++ b/src/utils/tests.h
@@ -15,22 +15,16 @@
  * along with Butterfly.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef _PG_UTILS_TESTS_H
+#define _PG_UTILS_TESTS_H
+
 #include <glib.h>
-#include <packetgraph/packetgraph.h>
-#include "utils/tests.h"
 
-void test_benchmark_tap(int argc, char **argv);
+extern int pg_skip_tests;
 
-int main(int argc, char **argv)
-{
-	struct pg_error *error = NULL;
-	int r;
+#define pg_test_add_func(name, func) do {		\
+		if (!pg_skip_tests)			\
+			g_test_add_func(name, func);	\
+	} while (0)
 
-	g_test_init(&argc, &argv, NULL);
-	pg_start(argc, argv, &error);
-	g_assert(!error);
-	test_benchmark_tap(argc, argv);
-	r = g_test_run();
-	pg_stop();
-	return r;
-}
+#endif

--- a/tests/antispoof/bench-antispoof.c
+++ b/tests/antispoof/bench-antispoof.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/antispoof.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/antispoof/bench.c
+++ b/tests/antispoof/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_antispoof(int argc, char **argv);
 

--- a/tests/antispoof/tests.c
+++ b/tests/antispoof/tests.c
@@ -21,6 +21,7 @@
 #include <rte_ether.h>
 #include <rte_ip.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/antispoof.h>
 #include "packetsgen.h"
 #include "brick-int.h"
@@ -413,19 +414,19 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	g_assert(!error);
 
-	g_test_add_func("/antispoof/mac",
+	pg_test_add_func("/antispoof/mac",
 			test_antispoof_mac);
-	g_test_add_func("/antispoof/rarp",
+	pg_test_add_func("/antispoof/rarp",
 			test_antispoof_rarp);
-	g_test_add_func("/antispoof/arp/request",
+	pg_test_add_func("/antispoof/arp/request",
 			test_antispoof_arp_request);
-	g_test_add_func("/antispoof/arp/response",
+	pg_test_add_func("/antispoof/arp/response",
 			test_antispoof_arp_response);
-	g_test_add_func("/antispoof/arp/gratuitous",
+	pg_test_add_func("/antispoof/arp/gratuitous",
 			test_antispoof_arp_gratuitous);
-	g_test_add_func("/antispoof/arp/disable",
+	pg_test_add_func("/antispoof/arp/disable",
 			test_pg_antispoof_arp_disable);
-	g_test_add_func("/antispoof/mac/burst_not_propagate",
+	pg_test_add_func("/antispoof/mac/burst_not_propagate",
 			test_antispoof_empty_burst);
 	r = g_test_run();
 

--- a/tests/core/bench-hub.c
+++ b/tests/core/bench-hub.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/hub.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/core/bench-nop.c
+++ b/tests/core/bench-nop.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/nop.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/core/bench.c
+++ b/tests/core/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_nop(int argc, char **argv);
 void test_benchmark_hub(int argc, char **argv);

--- a/tests/core/test-core.c
+++ b/tests/core/test-core.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 
 #include <packetgraph/nop.h>
+#include "utils/tests.h"
 #include "utils/config.h"
 #include "brick-int.h"
 #include "tests.h"
@@ -861,22 +862,22 @@ static void test_brick_verify_re_link_monopole(void)
 void test_brick_core(void)
 {
 	/* tests in the same order as the header function declarations */
-	g_test_add_func("/core/simple-lifecycle",
+	pg_test_add_func("/core/simple-lifecycle",
 			test_brick_core_simple_lifecycle);
-	g_test_add_func("/core/refcount", test_brick_core_refcount);
-	g_test_add_func("/core/link",	test_brick_core_link);
-	g_test_add_func("/core/unlink-edge",
+	pg_test_add_func("/core/refcount", test_brick_core_refcount);
+	pg_test_add_func("/core/link",	test_brick_core_link);
+	pg_test_add_func("/core/unlink-edge",
 			test_brick_core_unlink_edge);
-	g_test_add_func("/core/multiple-link",
+	pg_test_add_func("/core/multiple-link",
 			test_brick_core_multiple_link);
-	g_test_add_func("/core/multiple-unlink-edge",
+	pg_test_add_func("/core/multiple-unlink-edge",
 			test_brick_core_multiple_unlink_edge);
-	g_test_add_func("/core/multiple-unlink-edge-same",
+	pg_test_add_func("/core/multiple-unlink-edge-same",
 			test_brick_core_multiple_unlink_edge_same);
-	g_test_add_func("/core/verify/multiple-link",
+	pg_test_add_func("/core/verify/multiple-link",
 			test_brick_core_verify_multiple_link);
-	g_test_add_func("/core/verify/re-link",
+	pg_test_add_func("/core/verify/re-link",
 			test_brick_core_verify_re_link);
-	g_test_add_func("/core/verify/re_link_monopole",
+	pg_test_add_func("/core/verify/re_link_monopole",
 			test_brick_verify_re_link_monopole);
 }

--- a/tests/core/test-dot.c
+++ b/tests/core/test-dot.c
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "tests.h"
 
 #define RESULT_SIZE 100000
@@ -117,5 +118,5 @@ static void test_brick_core_dot(void)
 
 void test_brick_dot(void)
 {
-	g_test_add_func("/core/dot", test_brick_core_dot);
+	pg_test_add_func("/core/dot", test_brick_core_dot);
 }

--- a/tests/core/test-error.c
+++ b/tests/core/test-error.c
@@ -19,6 +19,7 @@
 #include <glib.h>
 
 #include <packetgraph/errors.h>
+#include "utils/tests.h"
 #include "tests.h"
 
 static void test_error_lifecycle(void)
@@ -110,8 +111,8 @@ static void test_error_format(void)
 
 void test_error(void)
 {
-	g_test_add_func("/error/lifecycle", test_error_lifecycle);
-	g_test_add_func("/error/vanilla", test_error_vanilla);
-	g_test_add_func("/error/errno", test_error_errno);
-	g_test_add_func("/error/format", test_error_format);
+	pg_test_add_func("/error/lifecycle", test_error_lifecycle);
+	pg_test_add_func("/error/vanilla", test_error_vanilla);
+	pg_test_add_func("/error/errno", test_error_errno);
+	pg_test_add_func("/error/format", test_error_format);
 }

--- a/tests/core/test-flow.c
+++ b/tests/core/test-flow.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 
 #include <packetgraph/nop.h>
+#include "utils/tests.h"
 #include "brick-int.h"
 #include "utils/bitmask.h"
 #include "utils/config.h"
@@ -224,6 +225,6 @@ static void test_brick_flow_east(void)
 void test_brick_flow(void)
 {
 	/* tests in the same order as the header function declarations */
-	g_test_add_func("/flow/west", test_brick_flow_west);
-	g_test_add_func("/flow/east", test_brick_flow_east);
+	pg_test_add_func("/flow/west", test_brick_flow_west);
+	pg_test_add_func("/flow/east", test_brick_flow_east);
 }

--- a/tests/core/test-graph.c
+++ b/tests/core/test-graph.c
@@ -21,6 +21,7 @@
 #include <rte_config.h>
 #include <rte_ether.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "tests.h"
 #include "packets.h"
 #include "brick-int.h"
@@ -690,10 +691,10 @@ static void test_graph_complex_merge(void)
 
 void test_graph(void)
 {
-	g_test_add_func("/core/graph/lifecycle", test_graph_lifecycle);
-	g_test_add_func("/core/graph/explore", test_graph_explore);
-	g_test_add_func("/core/graph/sanity", test_graph_sanity);
-	g_test_add_func("/core/graph/poll", test_graph_poll);
-	g_test_add_func("/core/graph/complex-merge", test_graph_complex_merge);
-	g_test_add_func("/core/graph/split-merge", test_graph_split_merge);
+	pg_test_add_func("/core/graph/lifecycle", test_graph_lifecycle);
+	pg_test_add_func("/core/graph/explore", test_graph_explore);
+	pg_test_add_func("/core/graph/sanity", test_graph_sanity);
+	pg_test_add_func("/core/graph/poll", test_graph_poll);
+	pg_test_add_func("/core/graph/complex-merge", test_graph_complex_merge);
+	pg_test_add_func("/core/graph/split-merge", test_graph_split_merge);
 }

--- a/tests/core/test-hub.c
+++ b/tests/core/test-hub.c
@@ -20,6 +20,7 @@
 #include <rte_mbuf.h>
 #include <string.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/hub.h>
 #include "brick-int.h"
 #include "packets.h"
@@ -343,7 +344,7 @@ static void test_hub_one_side_null(void)
 
 void test_hub(void)
 {
-	g_test_add_func("/hub/east", test_hub_east_dispatch);
-	g_test_add_func("/hub/west", test_hub_west_dispatch);
-	g_test_add_func("/hub/test_side_null", test_hub_one_side_null);
+	pg_test_add_func("/hub/east", test_hub_east_dispatch);
+	pg_test_add_func("/hub/west", test_hub_west_dispatch);
+	pg_test_add_func("/hub/test_side_null", test_hub_one_side_null);
 }

--- a/tests/core/test-pkts-count.c
+++ b/tests/core/test-pkts-count.c
@@ -24,6 +24,7 @@
 #include "utils/bitmask.h"
 #include "utils/config.h"
 #include "utils/mempool.h"
+#include "utils/tests.h"
 #include "packets.h"
 #include "collect.h"
 #include "tests.h"
@@ -146,6 +147,6 @@ static void test_brick_pkts_count_east(void)
 void test_pkts_count(void)
 {
 	/* tests in the same order as the header function declarations */
-	g_test_add_func("/core/pkts-counter/west", test_brick_pkts_count_west);
-	g_test_add_func("/core/pkts-counter/east", test_brick_pkts_count_east);
+	pg_test_add_func("/core/pkts-counter/west", test_brick_pkts_count_west);
+	pg_test_add_func("/core/pkts-counter/east", test_brick_pkts_count_east);
 }

--- a/tests/core/tests.c
+++ b/tests/core/tests.c
@@ -27,6 +27,7 @@
 #include <stdlib.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "tests.h"
 
 static void print_usage(void)

--- a/tests/diode/bench-diode.c
+++ b/tests/diode/bench-diode.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/diode.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/diode/bench.c
+++ b/tests/diode/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_diode(int argc, char **argv);
 

--- a/tests/diode/tests.c
+++ b/tests/diode/tests.c
@@ -18,6 +18,7 @@
 #include <glib.h>
 #include <string.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/diode.h>
 #include "brick-int.h"
 #include "packets.h"
@@ -171,13 +172,13 @@ static void test_diode_east_bad_direction(void)
 static void test_diode(void)
 {
 	/* tests in the same order as the header function declarations */
-	g_test_add_func("/diode/west/good",
+	pg_test_add_func("/diode/west/good",
 			test_diode_west_good_direction);
-	g_test_add_func("/diode/west/bad",
+	pg_test_add_func("/diode/west/bad",
 			test_diode_west_bad_direction);
-	g_test_add_func("/diode/east/good",
+	pg_test_add_func("/diode/east/good",
 			test_diode_east_good_direction);
-	g_test_add_func("/diode/east/bad",
+	pg_test_add_func("/diode/east/bad",
 			test_diode_east_bad_direction);
 }
 

--- a/tests/firewall/bench-firewall.c
+++ b/tests/firewall/bench-firewall.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/firewall.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/firewall/bench.c
+++ b/tests/firewall/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_firewall(int argc, char **argv);
 

--- a/tests/firewall/tests.c
+++ b/tests/firewall/tests.c
@@ -31,6 +31,7 @@
 #include <pcap/pcap.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/firewall.h>
 #include "brick-int.h"
 #include "collect.h"
@@ -805,13 +806,13 @@ static void test_firewall_empty_burst(void)
 
 static void test_firewall(void)
 {
-	g_test_add_func("/firewall/filter", test_firewall_filter);
-	g_test_add_func("/firewall/tcp", test_firewall_tcp);
-	g_test_add_func("/firewall/icmp", test_firewall_icmp);
-	g_test_add_func("/firewall/noip", test_firewall_noip);
-	g_test_add_func("/firewall/rules", test_firewall_rules);
-	g_test_add_func("/firewall/empty_burst", test_firewall_empty_burst);
-	g_test_add_func("/firewall/tcp6", test_firewall_tcp6);
+	pg_test_add_func("/firewall/filter", test_firewall_filter);
+	pg_test_add_func("/firewall/tcp", test_firewall_tcp);
+	pg_test_add_func("/firewall/icmp", test_firewall_icmp);
+	pg_test_add_func("/firewall/noip", test_firewall_noip);
+	pg_test_add_func("/firewall/rules", test_firewall_rules);
+	pg_test_add_func("/firewall/empty_burst", test_firewall_empty_burst);
+	pg_test_add_func("/firewall/tcp6", test_firewall_tcp6);
 }
 
 int main(int argc, char **argv)

--- a/tests/integration/tests.c
+++ b/tests/integration/tests.c
@@ -32,6 +32,7 @@
 #include <sys/wait.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/common.h>
 #include <packetgraph/nic.h>
 #include <packetgraph/vtep.h>
@@ -584,11 +585,11 @@ int main(int argc, char **argv)
 	if (test_flags & PRINT_USAGE)
 		print_usage();
 	g_assert(!(test_flags & FAIL));
-	g_test_add_func("/integration/graph/flow",
+	pg_test_add_func("/integration/graph/flow",
 			test_graph_type1);
-	g_test_add_func("/integration/graph/intense/solo",
+	pg_test_add_func("/integration/graph/intense/solo",
 			test_graph_firewall_intense);
-	g_test_add_func("/integration/graph/intense/multiple",
+	pg_test_add_func("/integration/graph/intense/multiple",
 			test_graph_firewall_intense_multiple);
 
 	r = g_test_run();

--- a/tests/ip-fragment/bench.c
+++ b/tests/ip-fragment/bench.c
@@ -21,6 +21,7 @@
 #include <rte_udp.h>
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/ip-fragment.h>
 
 #include "utils/bench.h"

--- a/tests/ip-fragment/tests.c
+++ b/tests/ip-fragment/tests.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 #include <rte_config.h>
 #include <rte_ip.h>
@@ -115,7 +116,7 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	g_assert(!error);
 
-	g_test_add_func("/ip_fragment/fragment", test_fragment);
+	pg_test_add_func("/ip_fragment/fragment", test_fragment);
 	r = g_test_run();
 
 	pg_stop();

--- a/tests/nic/bench-nic.c
+++ b/tests/nic/bench-nic.c
@@ -25,6 +25,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/nic.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/nic/bench.c
+++ b/tests/nic/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_nic(int argc, char **argv);
 

--- a/tests/nic/test-nic.c
+++ b/tests/nic/test-nic.c
@@ -26,6 +26,7 @@
 #include <packetgraph/common.h>
 #include <packetgraph/nic.h>
 #include <packetgraph/errors.h>
+#include "utils/tests.h"
 #include "utils/mempool.h"
 #include "utils/config.h"
 #include "brick-int.h"
@@ -112,5 +113,5 @@ static void test_nic_simple_flow(void)
 
 void test_nic(void)
 {
-	g_test_add_func("/nic/pcap/nic-pcap", test_nic_simple_flow);
+	pg_test_add_func("/nic/pcap/nic-pcap", test_nic_simple_flow);
 }

--- a/tests/nic/tests.c
+++ b/tests/nic/tests.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/nic.h>
 #include "tests.h"
 

--- a/tests/pmtud/bench.c
+++ b/tests/pmtud/bench.c
@@ -21,6 +21,7 @@
 #include <rte_udp.h>
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/pmtud.h>
 #include "utils/bench.h"
 #include "utils/bitmask.h"

--- a/tests/pmtud/tests.c
+++ b/tests/pmtud/tests.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/pmtud.h>
 #include <packetgraph/print.h>
 
@@ -222,9 +223,9 @@ static void test_icmp_pmtud(void)
 static void test_pmtud(void)
 {
 	/* tests in the same order as the header function declarations */
-	g_test_add_func("/pmtud/sorting/df", test_sorting_pmtud_df);
-	g_test_add_func("/pmtud/sorting/mtusize", test_sorting_pmtud);
-	g_test_add_func("/pmtud/integrity/icmp", test_icmp_pmtud);
+	pg_test_add_func("/pmtud/sorting/df", test_sorting_pmtud_df);
+	pg_test_add_func("/pmtud/sorting/mtusize", test_sorting_pmtud);
+	pg_test_add_func("/pmtud/integrity/icmp", test_icmp_pmtud);
 }
 
 int main(int argc, char **argv)

--- a/tests/print/bench-print.c
+++ b/tests/print/bench-print.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/print.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/print/bench.c
+++ b/tests/print/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_print(int argc, char **argv);
 

--- a/tests/print/tests.c
+++ b/tests/print/tests.c
@@ -24,6 +24,7 @@
 #include <netinet/udp.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/print.h>
 #include "brick-int.h"
 #include "packets.h"
@@ -194,8 +195,8 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	g_assert(!error);
 
-	g_test_add_func("/print/simple", test_print_simple);
-	g_test_add_func("/print/pcap", test_print_pcap);
+	pg_test_add_func("/print/simple", test_print_simple);
+	pg_test_add_func("/print/pcap", test_print_pcap);
 
 	r = g_test_run();
 

--- a/tests/queue/bench-queue.c
+++ b/tests/queue/bench-queue.c
@@ -25,6 +25,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "packets.h"
 #include "brick-int.h"
 #include "utils/bench.h"

--- a/tests/queue/bench.c
+++ b/tests/queue/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_queue(int argc, char **argv);
 

--- a/tests/queue/tests.c
+++ b/tests/queue/tests.c
@@ -24,6 +24,7 @@
 #include "utils/mac.h"
 #include "collect.h"
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 #define CHECK_ERROR(error) do {                 \
                if (error)                       \
@@ -505,11 +506,11 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	CHECK_ERROR(error);
 
-	g_test_add_func("/queue/lifecycle", test_queue_lifecycle);
-	g_test_add_func("/queue/friend", test_queue_friend);
-	g_test_add_func("/queue/burst", test_queue_burst);
-	g_test_add_func("/queue/limit", test_queue_limit);
-	g_test_add_func("/queue/reset", test_queue_reset);
+	pg_test_add_func("/queue/lifecycle", test_queue_lifecycle);
+	pg_test_add_func("/queue/friend", test_queue_friend);
+	pg_test_add_func("/queue/burst", test_queue_burst);
+	pg_test_add_func("/queue/limit", test_queue_limit);
+	pg_test_add_func("/queue/reset", test_queue_reset);
 	r = g_test_run();
 
 	pg_stop();

--- a/tests/rxtx/bench-rxtx.c
+++ b/tests/rxtx/bench-rxtx.c
@@ -25,6 +25,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "packets.h"
 #include "brick-int.h"
 #include "utils/bench.h"

--- a/tests/rxtx/bench.c
+++ b/tests/rxtx/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_rxtx(int argc, char **argv);
 

--- a/tests/rxtx/tests.c
+++ b/tests/rxtx/tests.c
@@ -25,6 +25,7 @@
 #include "fail.h"
 #include "collect.h"
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 #define CHECK_ERROR(error) do {                 \
 	if (error)                       \
@@ -226,10 +227,10 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	CHECK_ERROR(error);
 
-	g_test_add_func("/rxtx/lifecycle", test_rxtx_lifecycle);
-	g_test_add_func("/rxtx/rx_to_tx", test_rxtx_rx_to_tx);
-	g_test_add_func("/rxtx/rxtx_to_rxtx", test_rxtx_rxtx_to_rxtx);
-	g_test_add_func("/rxtx/rxtx_burst_not_propagate",
+	pg_test_add_func("/rxtx/lifecycle", test_rxtx_lifecycle);
+	pg_test_add_func("/rxtx/rx_to_tx", test_rxtx_rx_to_tx);
+	pg_test_add_func("/rxtx/rxtx_to_rxtx", test_rxtx_rxtx_to_rxtx);
+	pg_test_add_func("/rxtx/rxtx_burst_not_propagate",
 			test_rxtx_empty_burst);
 	r = g_test_run();
 

--- a/tests/switch/bench-switch.c
+++ b/tests/switch/bench-switch.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/switch.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/switch/bench.c
+++ b/tests/switch/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_switch(int argc, char **argv);
 

--- a/tests/switch/tests.c
+++ b/tests/switch/tests.c
@@ -24,6 +24,7 @@
 #include "utils/mac.h"
 #include "collect.h"
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/nop.h>
 #include <packetgraph/switch.h>
 
@@ -1254,16 +1255,16 @@ static void test_switch_perf_switch(void)
 static void test_switch(void)
 {
 	mbuf_pool = pg_get_mempool();
-	g_test_add_func("/switch/lifecycle", test_switch_lifecycle);
-	g_test_add_func("/switch/learn", test_switch_learn);
-	g_test_add_func("/switch/switching", test_switch_switching);
-	g_test_add_func("/switch/unlink", test_switch_unlink);
-	g_test_add_func("/switch/multicast/destination",
+	pg_test_add_func("/switch/lifecycle", test_switch_lifecycle);
+	pg_test_add_func("/switch/learn", test_switch_learn);
+	pg_test_add_func("/switch/switching", test_switch_switching);
+	pg_test_add_func("/switch/unlink", test_switch_unlink);
+	pg_test_add_func("/switch/multicast/destination",
 			test_switch_multicast_destination);
-	g_test_add_func("/switch/multicast/both", test_switch_multicast_both);
-	g_test_add_func("/switch/filtered", test_switch_filtered);
-	g_test_add_func("/switch/perf/learn", test_switch_perf_learn);
-	g_test_add_func("/switch/perf/switch", test_switch_perf_switch);
+	pg_test_add_func("/switch/multicast/both", test_switch_multicast_both);
+	pg_test_add_func("/switch/filtered", test_switch_filtered);
+	pg_test_add_func("/switch/perf/learn", test_switch_perf_learn);
+	pg_test_add_func("/switch/perf/switch", test_switch_perf_switch);
 }
 
 int main(int argc, char **argv)

--- a/tests/tap/bench-tap.c
+++ b/tests/tap/bench-tap.c
@@ -25,6 +25,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "packets.h"
 #include "brick-int.h"
 #include "utils/bench.h"

--- a/tests/tap/tests.c
+++ b/tests/tap/tests.c
@@ -26,6 +26,7 @@
 #include "utils/mac.h"
 #include "collect.h"
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 #define CHECK_ERROR(error) do {                 \
 	if (error)                       \
@@ -243,9 +244,9 @@ int main(int argc, char **argv)
 	pg_start(argc, argv, &error);
 	CHECK_ERROR(error);
 
-	g_test_add_func("/tap/lifecycle", test_tap_lifecycle);
-	g_test_add_func("/tap/com", test_tap_com);
-	g_test_add_func("/tap/mac", test_tap_mac);
+	pg_test_add_func("/tap/lifecycle", test_tap_lifecycle);
+	pg_test_add_func("/tap/com", test_tap_com);
+	pg_test_add_func("/tap/mac", test_tap_mac);
 	r = g_test_run();
 
 	pg_stop();

--- a/tests/vhost/bench-vhost.c
+++ b/tests/vhost/bench-vhost.c
@@ -25,6 +25,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/vhost.h>
 #include "packets.h"
 #include "brick-int.h"

--- a/tests/vhost/bench.c
+++ b/tests/vhost/bench.c
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_vhost(char *vm_path, char *vm_key_path,
 			  char *hugepages_path, int argc, char **argv);

--- a/tests/vhost/test-vhost.c
+++ b/tests/vhost/test-vhost.c
@@ -32,6 +32,7 @@
 #include <packetgraph/vhost.h>
 #include "collect.h"
 #include "packets.h"
+#include "utils/tests.h"
 #include "utils/mempool.h"
 #include "utils/bitmask.h"
 #include "brick-int.h"
@@ -628,10 +629,10 @@ static void test_vhost_destroy(void)
 
 void test_vhost(void)
 {
-	g_test_add_func("/vhost/flow", test_vhost_flow);
-	g_test_add_func("/vhost/multivm", test_vhost_multivm);
-	g_test_add_func("/vhost/fd", test_vhost_fd_loop);
+	pg_test_add_func("/vhost/flow", test_vhost_flow);
+	pg_test_add_func("/vhost/multivm", test_vhost_multivm);
+	pg_test_add_func("/vhost/fd", test_vhost_fd_loop);
 	if (glob_long_tests)
-		g_test_add_func("/vhost/reco", test_vhost_reco);
-	g_test_add_func("/vhost/destroy", test_vhost_destroy);
+		pg_test_add_func("/vhost/reco", test_vhost_reco);
+	pg_test_add_func("/vhost/destroy", test_vhost_destroy);
 }

--- a/tests/vhost/tests.c
+++ b/tests/vhost/tests.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include "tests.h"
 
 char *glob_vm_path;

--- a/tests/vtep/bench-vtep.c
+++ b/tests/vtep/bench-vtep.c
@@ -23,6 +23,7 @@
 #include <rte_ip.h>
 #include <rte_udp.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 #include <packetgraph/vtep.h>
 #include <packetgraph/nop.h>
 #include "packets.h"

--- a/tests/vtep/bench.c
+++ b/tests/vtep/bench.c
@@ -17,6 +17,7 @@
 
 #include <glib.h>
 #include <packetgraph/packetgraph.h>
+#include "utils/tests.h"
 
 void test_benchmark_vtep(int argc, char **argv);
 

--- a/tests/vtep/tests.c
+++ b/tests/vtep/tests.c
@@ -33,6 +33,7 @@
 #include <packetgraph/ip-fragment.h>
 
 #include "brick-int.h"
+#include "utils/tests.h"
 #include "utils/mempool.h"
 #include "utils/mac.h"
 #include "utils/bitmask.h"
@@ -815,22 +816,22 @@ int main(int argc, char **argv)
 	g_assert(r >= 0);
 	g_assert(!error);
 
-	g_test_add_func("/vtep/simple/no-flags", test_vtep_simple_no_flags);
-	g_test_add_func("/vtep/simple/no-inner-check",
+	pg_test_add_func("/vtep/simple/no-flags", test_vtep_simple_no_flags);
+	pg_test_add_func("/vtep/simple/no-inner-check",
 			test_vtep_simple_no_inner_check);
-	g_test_add_func("/vtep/simple/no-copy", test_vtep_simple_no_copy);
-	g_test_add_func("/vtep/simple/all-opti", test_vtep_simple_all_opti);
+	pg_test_add_func("/vtep/simple/no-copy", test_vtep_simple_no_copy);
+	pg_test_add_func("/vtep/simple/all-opti", test_vtep_simple_all_opti);
 
-	g_test_add_func("/vtep/vnis/all-opti", test_vtep_vnis_all_opti);
-	g_test_add_func("/vtep/vnis/no-copy", test_vtep_vnis_no_copy);
-	g_test_add_func("/vtep/vnis/no-flags", test_vtep_vnis_no_flags);
-	g_test_add_func("/vtep/vnis/no-inner-check",
+	pg_test_add_func("/vtep/vnis/all-opti", test_vtep_vnis_all_opti);
+	pg_test_add_func("/vtep/vnis/no-copy", test_vtep_vnis_no_copy);
+	pg_test_add_func("/vtep/vnis/no-flags", test_vtep_vnis_no_flags);
+	pg_test_add_func("/vtep/vnis/no-inner-check",
 			test_vtep_vnis_no_inner_check);
 
-	g_test_add_func("/vtep/flood/encapsulate", test_vtep_flood_encapsulate);
-	g_test_add_func("/vtep/flood/encap-decap", test_vtep_flood_encap_decap);
+	pg_test_add_func("/vtep/flood/encapsulate", test_vtep_flood_encapsulate);
+	pg_test_add_func("/vtep/flood/encap-decap", test_vtep_flood_encap_decap);
 
-	g_test_add_func("/vtep/fragmented/encap-decap",
+	pg_test_add_func("/vtep/fragmented/encap-decap",
 			test_vtep_fragment_encap_decap);
 
 	r = g_test_run();


### PR DESCRIPTION
add pg_test_add_func which is a wrapper to g_test_add_func,
but check is pg_skip_tests global is set, if so skipp the test

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>