### PR TITLE
build: clean dpdk_symbols_autogen.h durring autogen.sh

### DIFF
--- a/dpdk_symbols.sh
+++ b/dpdk_symbols.sh
@@ -18,6 +18,8 @@ for a in ${RTE_SDK}/build/lib/librte_*.a ; do
     fi
 done
 
+echo -n "" > dpdk_symbols_autogen.h
+
 cat $tmp | while read f; do
     echo "PG_DPDK_INIT($f)" >> dpdk_symbols_autogen.h
 done


### PR DESCRIPTION
Because when you use autogen.sh twice, you get each functions declared twice...

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>