### PR TITLE
build: remove useless stdarg.h from public headers

### DIFF
--- a/include/packetgraph/brick.h
+++ b/include/packetgraph/brick.h
@@ -18,7 +18,6 @@
 #ifndef _PG_BRICK_H
 #define _PG_BRICK_H
 
-#include <stdarg.h>
 #include <packetgraph/common.h>
 #include <packetgraph/errors.h>
 

--- a/include/packetgraph/packetgraph.h
+++ b/include/packetgraph/packetgraph.h
@@ -18,7 +18,6 @@
 #ifndef _PG_PACKETGRAPH_H
 #define _PG_PACKETGRAPH_H
 
-#include <stdarg.h>
 #include <packetgraph/common.h>
 #include <packetgraph/errors.h>
 #include <packetgraph/graph.h>


### PR DESCRIPTION
Signed-off-by: Jerome Jutteau <jerome.jutteau@outscale.com>