### PR TITLE
vhost: remove sleeps

### DIFF
--- a/tests/integration/tests.c
+++ b/tests/integration/tests.c
@@ -473,7 +473,6 @@ static void test_graph_firewall_intense(void)
 						PG_MAX_SIDE, 1, &error) == 0);
 		CHECK_ERROR_ASSERT(error);
 		pg_graph_destroy(graph);
-		sleep(1);
 	}
 
 	CHECK_ERROR_ASSERT(error);
@@ -528,9 +527,6 @@ static void test_graph_firewall_intense_multiple(void)
 		}
 		for (int j = 0; j < PG_BRANCHES_NB; j++)
 			pg_graph_destroy(graphs[j]);
-
-		/* FIXME: remove this once dpdk merge patch that shrink fdset */
-		sleep(1);
 	}
 
 	CHECK_ERROR_ASSERT(error);

--- a/tests/vhost/test-vhost.c
+++ b/tests/vhost/test-vhost.c
@@ -414,7 +414,6 @@ static void test_vhost_fd(void)
 			pg_brick_destroy(vhost[i]);
 			g_assert(!error);
 		}
-		sleep(1);
 	}
 	pg_vhost_stop();
 }


### PR DESCRIPTION
the patch that shrink fdset has been merge in DPDK

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>