### PR TITLE
pg: use basic type when basic type are meant to be use

### DIFF
--- a/src/nic.c
+++ b/src/nic.c
@@ -327,7 +327,7 @@ static int nic_init(struct pg_brick *brick, struct pg_brick_config *config,
 
 	/* Setup port id */
 	if (nic_config->ifname[0]) {
-		gchar *tmp = g_strdup_printf("%s", nic_config->ifname);
+		char *tmp = g_strdup_printf("%s", nic_config->ifname);
 
 		if (rte_eth_dev_attach(tmp, &state->portid) < 0) {
 			*errp = pg_error_new("Invalid parameter %s",

--- a/src/queue.c
+++ b/src/queue.c
@@ -72,7 +72,7 @@ static int queue_burst(struct pg_brick *brick, enum pg_side from,
 	struct pg_queue_burst *burst = NULL;
 
 	/* the oldest burst is throw away */
-	if (g_async_queue_length(state->rx) >= (gint) state->rx_max_size) {
+	if (g_async_queue_length(state->rx) >= (int) state->rx_max_size) {
 		burst = g_async_queue_try_pop(state->rx);
 		if (likely(burst != NULL)) {
 			pg_packets_free(burst->pkts, burst->mask);

--- a/src/utils/qemu.c
+++ b/src/utils/qemu.c
@@ -26,7 +26,7 @@
 int pg_util_cmdloop(const char *cmd, int timeout_s)
 {
 	struct timeval start, end;
-	gint status;
+	int status;
 
 	gettimeofday(&start, 0);
 	gettimeofday(&end, 0);
@@ -44,8 +44,8 @@ int pg_util_ssh(const char *host,
 		const char *key_path,
 		const char *cmd, ...)
 {
-	gchar *ssh_cmd;
-	gint status;
+	char *ssh_cmd;
+	int status;
 	va_list args;
 	char *c;
 
@@ -76,11 +76,11 @@ int pg_util_spawn_qemu(const char *socket_path_0,
 {
 	int child_pid = 0;
 	static uint16_t vm_id;
-	gchar **argv = NULL;
-	gchar *argv_qemu = NULL;
-	gchar *argv_sock_0 = NULL;
-	gchar *argv_sock_1 = NULL;
-	gchar *ssh_cmd = NULL;
+	char **argv = NULL;
+	char *argv_qemu = NULL;
+	char *argv_sock_0 = NULL;
+	char *argv_sock_1 = NULL;
+	char *ssh_cmd = NULL;
 	GError *error = NULL;
 
 	g_assert(g_file_test(socket_path_0, G_FILE_TEST_EXISTS));

--- a/tests/core/test-graph.c
+++ b/tests/core/test-graph.c
@@ -206,7 +206,7 @@ static void test_graph_explore(void)
 	struct pg_graph *g1, *g2;
 	struct pg_error *error = NULL;
 	struct pg_brick *nop[7], *queue[3], *sw[2];
-	gchar *tmp;
+	char *tmp;
 
 	for (int i = 0; i < 7; i++) {
 		tmp = g_strdup_printf("nop%i", i);
@@ -353,7 +353,7 @@ static void test_graph_sanity(void)
 	struct pg_graph *g;
 	struct pg_error *error = NULL;
 	struct pg_brick *nop[4];
-	gchar *tmp;
+	char *tmp;
 
 	for (int i = 0; i < 4; i++) {
 		tmp = g_strdup_printf("nop%i", i);
@@ -417,7 +417,7 @@ static void test_graph_poll(void)
 	struct pg_graph *g, *trash;
 	struct pg_error *error = NULL;
 	struct pg_brick *queue[6], *hub;
-	gchar *tmp;
+	char *tmp;
 	struct rte_mbuf *pkts[NB_PKTS];
 	uint64_t mask = pg_mask_firsts(NB_PKTS);
 	struct rte_mempool *mbuf_pool = pg_get_mempool();
@@ -537,7 +537,7 @@ static void test_graph_split_merge(void)
 	struct pg_graph *g, *east;
 	struct pg_error *error = NULL;
 	struct pg_brick *nop[4];
-	gchar *tmp;
+	char *tmp;
 
 	for (int i = 0; i < 4; i++) {
 		tmp = g_strdup_printf("nop%i", i);

--- a/tests/nic/test-nic.c
+++ b/tests/nic/test-nic.c
@@ -58,7 +58,7 @@ static void test_nic_simple_flow(void)
 	 */
 
 	/* write rx pcap file (required bu pcap driver) */
-	const gchar pcap_in_file[] = {
+	const char pcap_in_file[] = {
 		212, 195, 178, 161, 2, 0, 4, 0, 0, 0, 0,
 		0, 0, 0, 0, 0, 255, 255, 0, 0, 1, 0, 0, 0};
 	g_assert(g_file_set_contents("in.pcap", pcap_in_file,

--- a/tests/rxtx/tests.c
+++ b/tests/rxtx/tests.c
@@ -37,7 +37,7 @@
 static void test_rxtx_lifecycle(void)
 {
 	struct pg_brick *brick;
-	gchar *pd = g_strdup_printf("ho hai !");
+	char *pd = g_strdup_printf("ho hai !");
 
 	brick = pg_rxtx_new("rxtx", NULL, NULL, NULL);
 	g_assert(brick);

--- a/tests/vhost/test-vhost.c
+++ b/tests/vhost/test-vhost.c
@@ -394,7 +394,7 @@ static void test_vhost_fd(void)
 
 	for (int j = 0; j < 10; j++) {
 		for (int i = 0; i < VHOST_CNT; i++) {
-			gchar *name = g_strdup_printf("vhost-%i", i);
+			char *name = g_strdup_printf("vhost-%i", i);
 
 			vhost[i] =
 				pg_vhost_new(name,


### PR DESCRIPTION
As glib manual specify: gchar, and gint are simple typedef of char and int
and will always be, so they're a mistake(and useless) and should not be use.

the official reason is: "uniformity", but I'm not smart enough
to understand what that mean, or the point of this.

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>