### PR TITLE
thread: fix unrelated comment

### DIFF
--- a/include/packetgraph/thread.h
+++ b/include/packetgraph/thread.h
@@ -118,7 +118,6 @@ struct pg_graph *pg_thread_pop_graph(int16_t tid, int32_t graph_id);
  * @param   tid the thread id to be destroy
  * @return  0 on success, -1 on failure
  */
-
 int pg_thread_destroy(int16_t tid);
 
 #endif

--- a/src/thread-internal.c
+++ b/src/thread-internal.c
@@ -13,11 +13,6 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with Butterfly.  If not, see <http://www.gnu.org/licenses/>.
- *
- * The multicast_subscribe and multicast_unsubscribe functions
- * are modifications of igmpSendReportMessage/igmpSendLeaveGroupMessage from
- * CycloneTCP Open project.
- * Copyright 2010-2015 Oryx Embedded SARL.(www.oryx-embedded.com)
  */
 
 #ifndef TYPE_NAME


### PR DESCRIPTION
this comment is about vtep, don't know how it end up in thread,
but there is no code from cyclone tcp in thread.h

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>