### PR TITLE
Udp filter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ PG_SOURCES = \
 			 src/utils/tests.c\
 			 src/print.c\
 			 src/hub.c\
+			 src/udp-filter.c\
 			 src/brick.c\
 			 src/packetsgen.c\
 			 src/vhost.c\

--- a/include/packetgraph/udp-filter.h
+++ b/include/packetgraph/udp-filter.h
@@ -1,0 +1,52 @@
+/* Copyright 2020 Outscale SAS
+ *
+ * This file is part of Packetgraph.
+ *
+ * Packetgraph is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * Packetgraph is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Packetgraph.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PG_UDP_FILTER_H_
+#define PG_UDP_FILTER_H_
+
+#include <packetgraph/errors.h>
+
+#define PG_USP_FILTER_DST_PORT 1 << 0
+#define PG_USP_FILTER_SRC_PORT 1 << 1
+
+struct pg_udp_filter_info {
+	uint16_t udp_src_port;
+	uint16_t udp_dst_port;
+	uint32_t flag;
+};
+
+/**
+ * Create a new hub brick
+ *
+ * @param	name name of the brick
+ * @param	ports array of pg_udp_port_sw_info that describe where
+ *		packets goes
+ * @param	nb_filters self explainatory ?
+ * @param	output side where packets need filtering
+ * @param	errp is set in case of an error
+ * @return	a pointer to a brick structure on success, NULL on error
+ */
+PG_WARN_UNUSED
+struct pg_brick *pg_udp_filter_new(const char *name,
+				   struct pg_udp_filter_info ports[],
+				   int nb_filters,
+				   enum pg_side output,
+				   struct pg_error **errp);
+
+
+#endif  /* PG_UDP_FILTER_H_ */
+

--- a/src/udp-filter.c
+++ b/src/udp-filter.c
@@ -1,0 +1,201 @@
+/* Copyright 2020 Outscale SAS
+ *
+ * This file is part of Packetgraph.
+ *
+ * Packetgraph is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * Packetgraph is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Packetgraph.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <rte_config.h>
+#include <rte_errno.h>
+#include <rte_ether.h>
+#include <rte_ip.h>
+#include <rte_udp.h>
+
+#include <packetgraph/packetgraph.h>
+#include <packetgraph/udp-filter.h>
+
+#include "utils/bitmask.h"
+#include "utils/ip.h"
+#include "brick-int.h"
+
+struct pg_udp_filter_config {
+	enum pg_side to;
+	struct pg_udp_filter_info *ports;
+	int nb_filters;
+};
+
+struct pg_udp_filter_state {
+	struct pg_brick brick;
+	enum pg_side to;
+	struct pg_udp_filter_info *filters;
+	int nb_filters;
+};
+
+struct header {
+	struct ether_hdr ethernet;
+	struct ipv4_hdr    ip;
+	struct udp_hdr   udp;
+}  __attribute__((__packed__));
+
+static int udp_filter_burst(struct pg_brick *brick, enum pg_side from,
+			    uint16_t edge_index, struct rte_mbuf **pkts,
+			    uint64_t pkts_mask, struct pg_error **errp)
+{
+	int ret;
+	struct pg_udp_filter_state *state =
+		pg_brick_get_state(brick, struct pg_udp_filter_state);
+	struct pg_brick_side *s = &brick->sides[pg_flip_side(from)];
+	struct pg_brick_edge *edges = s->edges;
+	int nb_filters = state->nb_filters;
+	int nb_ports = nb_filters + 1;
+	struct pg_udp_filter_info *filters = state->filters;
+	/*
+	 * So it's a VLA,  but number of filters should be limited
+	 * As it's the packatgraph user that configure it,
+	 * If correctly configure we should never have stack overflow
+	 */
+	uint64_t port_mask[nb_ports];
+
+	if (from == state->to)
+		return pg_brick_side_forward(s, from, pkts, pkts_mask, errp);
+
+	memset(port_mask, 0, nb_ports * sizeof(*port_mask));
+
+	/* came from filtered side, so no filters aply here */
+	PG_FOREACH_BIT(pkts_mask, i) {
+		struct rte_mbuf *pkt = pkts[i];
+		struct header *hdr = pg_packet_cast_data(pkt, struct header);
+
+		/* true mean default case */
+		if (hdr->ethernet.ether_type != PG_BE_ETHER_TYPE_IPv4 ||
+		    hdr->ip.next_proto_id != PG_UDP_PROTOCOL_NUMBER) {
+			port_mask[0] |= 1LLU << i;
+		}
+
+		for (int j = 0; j < nb_filters; ++j) {
+			uint32_t filter_flag = filters[j].flag;
+
+			if (filter_flag & PG_USP_FILTER_DST_PORT &&
+			    hdr->udp.dst_port == filters[j].udp_dst_port) {
+				port_mask[j + 1] |= 1LLU << i;
+				goto next;
+			}
+			if (filter_flag & PG_USP_FILTER_SRC_PORT &&
+			    hdr->udp.src_port == filters[j].udp_src_port) {
+				port_mask[j + 1] |= 1LLU << i;
+				goto next;
+			}
+		}
+		port_mask[0] |= 1LLU << i;
+next:;
+	}
+
+	for (int i = 0; i < nb_ports; ++i) {
+		ret = pg_brick_burst(edges[i].link,
+				     from,
+				     edges[i].pair_index,
+				     pkts, port_mask[i], errp);
+		if (unlikely(ret < 0))
+			return ret;
+	}
+	return 0;
+}
+
+static int udp_filter_init(struct pg_brick *brick,
+			   struct pg_brick_config *config,
+			   struct pg_error **errp)
+{
+	struct pg_udp_filter_state *s =
+		pg_brick_get_state(brick, struct pg_udp_filter_state);
+	struct pg_udp_filter_config *fc = config->brick_config;
+	int nb_f = fc->nb_filters;
+	struct pg_udp_filter_info *pts = fc->ports;
+
+	/* initialize fast path */
+	brick->burst = udp_filter_burst;
+	s->to = fc->to;
+	s->filters = g_new(struct pg_udp_filter_info, nb_f);
+	/* let's store port as network endian */
+	for (int i = 0; i < nb_f; ++i) {
+		s->filters[i].flag = pts[i].flag;
+		s->filters[i].udp_src_port =
+			rte_cpu_to_be_16(pts[i].udp_src_port);
+		s->filters[i].udp_dst_port =
+			rte_cpu_to_be_16(pts[i].udp_dst_port);
+	}
+	s->nb_filters = nb_f;
+	return 0;
+}
+
+static struct pg_brick_config *config_new(const char *name,
+					  uint32_t west_max,
+					  uint32_t east_max,
+					  enum pg_side output)
+{
+	struct pg_brick_config *config = g_new0(struct pg_brick_config, 1);
+	struct pg_udp_filter_config *udp_filter_config =
+		g_new0(struct pg_udp_filter_config, 1);
+
+	udp_filter_config->to = output;
+	config->brick_config = udp_filter_config;
+	return  pg_brick_config_init(config, name, west_max,
+				     east_max, PG_MULTIPOLE);
+}
+
+struct pg_brick *pg_udp_filter_new(const char *name,
+				   struct pg_udp_filter_info ports[],
+				   int nb_filters,
+				   enum pg_side output,
+				   struct pg_error **errp)
+{
+	if (!ports) {
+		*errp = pg_error_new("port is NULL");
+		return NULL;
+	}
+
+	int nb_east = output == PG_EAST_SIDE ? nb_filters + 1 : 1;
+	int nb_west = output == PG_WEST_SIDE ? nb_filters + 1 : 1;
+	struct pg_brick_config *config = config_new(name, nb_west,
+						    nb_east,
+						    output);
+	struct pg_udp_filter_config *udp_filter_config = config->brick_config;
+	struct pg_brick *ret;
+
+	udp_filter_config->nb_filters = nb_filters;
+	udp_filter_config->ports = ports;
+	ret = pg_brick_new("udp_filter", config, errp);
+
+	pg_brick_config_free(config);
+	return ret;
+}
+
+static void udp_filter_destroy(struct pg_brick *brick,
+			       struct pg_error **errp)
+{
+	struct  pg_udp_filter_state* state =
+		pg_brick_get_state(brick, struct pg_udp_filter_state);
+
+	g_free(state->filters);
+}
+
+static struct pg_brick_ops udp_filter_ops = {
+	.name		= "udp_filter",
+	.state_size	= sizeof(struct pg_udp_filter_state),
+
+	.init		= udp_filter_init,
+
+	.destroy	= udp_filter_destroy,
+	.unlink		= pg_brick_generic_unlink,
+};
+
+pg_brick_register(udp_filter, &udp_filter_ops);

--- a/src/utils/common.h
+++ b/src/utils/common.h
@@ -34,6 +34,8 @@ static inline void pg_autofree_(void *p)
 #define pg_autofree				\
 	__attribute__((__cleanup__(pg_autofree_)))
 
+#define pg_autobrick						\
+	__attribute__((__cleanup__(pg_brick_ptrptr_destroy)))
 
 static inline void pg_brick_ptrptr_destroy(struct pg_brick **brick)
 {

--- a/src/vhost.c
+++ b/src/vhost.c
@@ -178,9 +178,6 @@ static int vhost_burst(struct pg_brick *brick, enum pg_side from,
 	return 0;
 }
 
-#define TCP_PROTOCOL_NUMBER 6
-#define UDP_PROTOCOL_NUMBER 17
-
 #ifdef PG_VHOST_FASTER_YET_BROKEN_POLL
 
 void pg_vhost_request_remove(struct pg_brick *brick)
@@ -260,9 +257,6 @@ static int vhost_poll(struct pg_brick *brick, uint16_t *pkts_cnt,
 	pg_packets_free(in, pkts_mask);
 	return ret;
 }
-
-#undef TCP_PROTOCOL_NUMBER
-#undef UDP_PROTOCOL_NUMBER
 
 #ifndef RTE_VHOST_USER_CLIENT
 #define RTE_VHOST_USER_CLIENT 0

--- a/tests.mk
+++ b/tests.mk
@@ -25,6 +25,11 @@ tests_diode_SOURCES = \
 	$(tests_diode_DIR)/tests.c
 tests_diode_OBJECTS = $(tests_diode_SOURCES:.c=.o)
 
+tests_udp_filter_DIR = tests/udp-filter
+tests_udp_filter_SOURCES = \
+	$(tests_udp_filter_DIR)/tests.c
+tests_udp_filter_OBJECTS = $(tests_udp_filter_SOURCES:.c=.o)
+
 tests_accumulator_DIR = tests/accumulator
 tests_accumulator_SOURCES = \
 	$(tests_accumulator_DIR)/tests.c
@@ -113,6 +118,7 @@ TESTS = \
 	tests/vtep/test.sh\
 	tests/tap/test.sh\
 	tests/thread/test.sh\
+	tests/udp-filter/test.sh\
 	tests/integration/test.sh\
 	tests/vhost/test.sh
 
@@ -120,10 +126,10 @@ TESTS = \
 ##                           Tests compilation rules                          ##
 ################################################################################
 
-test: dev tests-all-build antispoof core diode rxtx pmtud firewall nic print queue switch vtep tap thread integration vhost accumulator
+test: dev tests-all-build antispoof core diode rxtx pmtud firewall nic print queue switch vtep tap thread integration udp-filter vhost accumulator
 	@echo "tests ended"
 
-tests_compile: dev tests-antispoof tests-core tests-diode tests-rxtx tests-pmtud tests-integration tests-nic tests-print tests-queue tests-switch tests-vhost tests-vtep tests-tap tests-thread tests-firewall tests-accumulator
+tests_compile: dev tests-antispoof tests-core tests-diode tests-rxtx tests-pmtud tests-integration tests-nic tests-print tests-queue tests-switch tests-vhost tests-vtep tests-tap tests-thread tests-udp-filter tests-firewall tests-accumulator
 	@echo "Compilation done"
 
 tests-antispoof: dev $(tests_antispoof_OBJECTS)
@@ -136,6 +142,12 @@ tests-core: dev $(tests_core_OBJECTS)
 	$(CC) $(tests_CFLAGS) $(PG_ASAN_CFLAGS) $(tests_core_OBJECTS) $(tests_LIBS) -o $@
 
 $(tests_core_OBJECTS): %.o : %.c
+	$(CC) -c $(tests_CFLAGS) $(PG_ASAN_CFLAGS) $< -o $@
+
+tests-udp-filter: dev $(tests_udp_filter_OBJECTS)
+	$(CC) $(tests_CFLAGS) $(PG_ASAN_CFLAGS) $(tests_udp_filter_OBJECTS) $(tests_LIBS) -o $@
+
+$(tests_udp_filter_OBJECTS): %.o : %.c
 	$(CC) -c $(tests_CFLAGS) $(PG_ASAN_CFLAGS) $< -o $@
 
 tests-diode: dev $(tests_diode_OBJECTS)

--- a/tests/udp-filter/test.sh
+++ b/tests/udp-filter/test.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+sudo ./tests-udp-filter -c1 -n1 --socket-mem 64 --no-shconf

--- a/tests/udp-filter/tests.c
+++ b/tests/udp-filter/tests.c
@@ -1,0 +1,93 @@
+/* Copyright 2020 Outscale SAS
+ *
+ * This file is part of Packetgraph.
+ *
+ * Packetgraph is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as published
+ * by the Free Software Foundation.
+ *
+ * Packetgraph is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Packetgraph.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <glib.h>
+
+#include <rte_config.h>
+#include <rte_ether.h>
+
+#include <packetgraph/packetgraph.h>
+#include <packetgraph/udp-filter.h>
+
+#include "utils/tests.h"
+#include "collect.h"
+#include "packets.h"
+#include "utils/common.h"
+#include "brick-int.h"
+
+static void test_udp_filter(void)
+{
+	struct pg_error *error = NULL;
+	struct rte_mbuf **pkts = pg_packets_create(-1LL);
+	struct rte_mbuf **result_pkts;
+	uint64_t pkts_mask;
+
+	pg_autobrick struct pg_brick *collect_east0 =
+		pg_collect_new("collect-east0", &error);
+	pg_autobrick struct pg_brick *collect_east1 =
+		pg_collect_new("collect-east1", &error);
+	pg_autobrick struct pg_brick *sw =
+		pg_udp_filter_new(
+			"sw_udp",
+			(struct pg_udp_filter_info [])
+			{{68, 67, PG_USP_FILTER_SRC_PORT}},
+			1, PG_EAST_SIDE, &error);
+
+	pg_packets_append_ether(pkts, -1LL,
+				&(struct ether_addr){{0, 1}},
+				&(struct ether_addr){{0xff}},
+				ETHER_TYPE_IPv4
+		);
+	pg_packets_append_ipv4(pkts, -1LL, 0, -1, 10, 17);
+	pg_packets_append_udp(pkts, 0xffffffffLU, 68, 67, 1000);
+	pg_packets_append_udp(pkts, ~0xffffffffLU, 60, 61, 1000);
+
+	pg_brick_link(sw, collect_east0, &error);
+	pg_brick_link(sw, collect_east1, &error);
+
+	pg_brick_burst_to_east(sw, 0, pkts, -1LL, &error);
+	if (error)
+		pg_error_print(error);
+	g_assert(!error);
+	result_pkts = pg_brick_west_burst_get(collect_east0, &pkts_mask,
+					      &error);
+	g_assert(pkts_mask == ~0xffffffffLU);
+	g_assert(result_pkts);
+
+	result_pkts = pg_brick_west_burst_get(collect_east1, &pkts_mask,
+					      &error);
+	g_assert(pkts_mask == 0xffffffffLLU);
+	g_assert(result_pkts);
+
+	pg_packets_free(pkts, -1LL);
+}
+
+int main(int argc, char **argv)
+{
+	int r;
+
+	g_test_init(&argc, &argv, NULL);
+	g_assert(pg_start(argc, argv) >= 0);
+
+	pg_test_add_func("/udp-filtering",
+			 test_udp_filter);
+
+	r = g_test_run();
+
+	pg_stop();
+	return r;
+}

--- a/tests_travis/test_all.sh
+++ b/tests_travis/test_all.sh
@@ -26,6 +26,7 @@ make bench_compile
 ./tests/pmtud/test.sh
 ./tests/tap/test.sh
 ./tests/thread/test.sh
+./tests/udp-filter/test.sh
 
 ./tests/antispoof/bench.sh
 ./tests/core/bench.sh


### PR DESCRIPTION
DHCP use always the same UDP port, so this brick enable us to redirect DHCP
trafick into our own conponant.

Add a brick that allow to do udp port filtering
I've call this brick udp-filter insyead of udp port filtering
because in the futur it's posible to add more kind of filter.

Been udp only enable to pass all non udp packets to default path.

This brick is entierly configure at brick creation,
because it was easier that way.

also some small fixes and rogues changes 